### PR TITLE
Cargo: ignore tests & snapshots in build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ description = """
 The Cleasby/Vigfusson Old Norse to English Dictionary for Rust
 """
 edition = "2018"
+exclude = ["tests/*"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Snapshots are quite large, no need to distribute them